### PR TITLE
Fix the URI-Reference paring in the LinkFormat parser to match RFC6690

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/LinkFormat.java
@@ -232,7 +232,7 @@ public class LinkFormat {
 		if (linkFormat!=null) {
 			Scanner scanner = new Scanner(linkFormat);
 			String path = null;
-			while ((path = scanner.findInLine("</[^>]*>")) != null) {
+			while ((path = scanner.findInLine("<[^>]*>")) != null) {
 				
 				// Trim <...>
 				path = path.substring(1, path.length() - 1);


### PR DESCRIPTION
Support uri references which do not start with a slash.

link-value     = "<" URI-Reference ">" *( ";" link-param )
