### PR TITLE
Fix null pointer exception in CoapClient

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/CoapClient.java
@@ -291,6 +291,11 @@ public class CoapClient {
 		}
 		CoapResponse links = synchronous(discover);
 		
+		// if the response is null return null (if timeout occurred)
+		if(links == null){
+			return null;
+		}
+
 		// check if Link Format
 		if (links.getOptions().getContentFormat()!=MediaTypeRegistry.APPLICATION_LINK_FORMAT)
 			return Collections.emptySet();


### PR DESCRIPTION
If a time out occurs in the discover request the variable link is set to null. This caused a null pointer exception.
