### PR TITLE
add a BundleActivator to start/stop a ManagedServer

### DIFF
--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -85,6 +85,12 @@
 						</Import-Package>
 						<Embed-Dependency>californium-core;inline=true,element-connector;inline=true</Embed-Dependency>
 						<Bundle-SymbolicName>californium-osgi</Bundle-SymbolicName>
+						
+						<!-- added for Activator -->
+						<Bundle-Activator>${groupId}.osgi.Activator</Bundle-Activator>
+						<Export-Service>org.osgi.service.cm.ManagedService</Export-Service>
+						<Import-Service>org.eclipse.californium.core.server.resources.Resource</Import-Service>
+						
 					</instructions>
 				</configuration>
 			</plugin>

--- a/californium-osgi/src/main/java/org/eclipse/californium/osgi/Activator.java
+++ b/californium-osgi/src/main/java/org/eclipse/californium/osgi/Activator.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ ******************************************************************************/
+package org.eclipse.californium.osgi;
+
+import java.net.InetSocketAddress;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.network.Endpoint;
+import org.eclipse.californium.core.network.EndpointManager;
+import org.eclipse.californium.core.network.config.NetworkConfig;
+import org.eclipse.californium.core.server.ServerInterface;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.cm.ManagedService;
+
+
+/**
+ * Example of BundleActivator to start and stop a managed server
+ * @author Didier Donsez
+ *
+ */
+
+public class Activator implements BundleActivator {
+	
+	private final static Logger LOGGER = Logger.getLogger(ManagedServer.class.getCanonicalName());
+
+	ServerInterfaceFactory serverFactory;
+	ServerInterface server;
+	ManagedServer managedServer;
+	BundleContext bundleContext;
+	EndpointFactory endpointFactory;
+	EndpointFactory secureEndpointFactory;
+	List<Endpoint> endpointList = new LinkedList<Endpoint>();
+	Endpoint standardEndpoint;
+	Endpoint secureEndpoint;
+	
+    ServiceRegistration<ManagedService> serviceRegistration;
+	
+	InetSocketAddress standardAddress = new InetSocketAddress(EndpointManager.DEFAULT_COAP_PORT);
+	InetSocketAddress secureAddress = new InetSocketAddress(EndpointManager.DEFAULT_COAP_PORT);
+	
+	@Override
+	public void start(BundleContext bundleContext) throws Exception {
+		LOGGER.fine("managed server instance is starting");
+
+		this.bundleContext=bundleContext;
+		
+		serverFactory = new ServerInterfaceFactory() {
+			
+			@Override
+			public ServerInterface newServer(NetworkConfig config) {
+				return newServer(config, EndpointManager.DEFAULT_COAP_PORT);
+			}
+
+			@Override
+			public ServerInterface newServer(NetworkConfig config, int... ports) {
+				for (int port : ports) {
+					if (port == standardAddress.getPort()) {
+						endpointList.add(standardEndpoint);
+					} else if (port == secureAddress.getPort()) {
+						endpointList.add(secureEndpoint);
+					}
+				}
+				return server;
+			}
+		};
+
+		endpointFactory = new EndpointFactory() {
+			
+			@Override
+			public Endpoint getSecureEndpoint(NetworkConfig config,
+					InetSocketAddress address) {
+				return null;
+			}
+			
+			@Override
+			public Endpoint getEndpoint(NetworkConfig config, InetSocketAddress address) {
+				return standardEndpoint;
+			}
+		};
+		//managedServer = new ManagedServer(bundleContext, serverFactory, endpointFactory);
+		managedServer = new ManagedServer(bundleContext, endpointFactory);
+
+		try {
+			java.util.Dictionary properties=new java.util.Hashtable();
+			properties.put(org.osgi.framework.Constants.SERVICE_PID, ManagedServer.class.getName());
+			serviceRegistration=(ServiceRegistration<ManagedService>) bundleContext.registerService(ManagedService.class.getName(),managedServer,properties);			
+		} catch (Exception e) {
+			LOGGER.warning("Could not register the ManagedService service of managed server instance");
+			throw e;
+		}
+		LOGGER.fine("managed server instance is started");
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		if(serviceRegistration!=null) serviceRegistration.unregister();
+		managedServer.stop();
+		managedServer = null;
+		LOGGER.fine("managed server instance is stopped");
+	}	
+}

--- a/cf-helloworld-osgi/.classpath
+++ b/cf-helloworld-osgi/.classpath
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/cf-helloworld-osgi/.project
+++ b/cf-helloworld-osgi/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>cf-helloworld-osgi</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/cf-helloworld-osgi/pom.xml
+++ b/cf-helloworld-osgi/pom.xml
@@ -1,0 +1,69 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<osgi.version>4.3.1</osgi.version>
+	</properties>
+
+	<parent>
+		<groupId>org.eclipse.californium</groupId>
+		<artifactId>root</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>cf-helloworld-OSGi</artifactId>
+	<packaging>bundle</packaging>
+
+	<name>Cf-HelloWorldOSGi</name>
+	<description>Californium (Cf) example for OSGi wrapper</description>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.eclipse.californium</groupId>
+			<artifactId>californium-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.core</artifactId>
+			<version>${osgi.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.osgi</groupId>
+			<artifactId>org.osgi.compendium</artifactId>
+			<version>${osgi.version}</version>
+			<scope>provided</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-Activator>${groupId}.examples.Activator</Bundle-Activator>
+						<Import-Package>
+							org.osgi.framework,
+							org.eclipse.californium.core, org.eclipse.californium.core.server.resources						
+						</Import-Package>
+						<Export-Package>
+						</Export-Package>
+						<Export-Service>org.eclipse.californium.core.server.resources.Resource</Export-Service>
+						<Bundle-SymbolicName>helloworld-osgi</Bundle-SymbolicName>
+					</instructions>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/cf-helloworld-osgi/src/main/java/org/eclipse/californium/examples/Activator.java
+++ b/cf-helloworld-osgi/src/main/java/org/eclipse/californium/examples/Activator.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Institute for Pervasive Computing, ETH Zurich and others.
+ * 
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v1.0 which accompany this distribution.
+ * 
+ * The Eclipse Public License is available at
+ *    http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ *    http://www.eclipse.org/org/documents/edl-v10.html.
+ * 
+ * Contributors:
+ *    Matthias Kovatsch - creator and main architect
+ ******************************************************************************/
+package org.eclipse.californium.examples;
+
+import java.util.logging.Logger;
+
+import org.eclipse.californium.core.CoapResource;
+import org.eclipse.californium.core.server.resources.CoapExchange;
+import org.eclipse.californium.core.server.resources.Resource;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * Example of BundleActivator registering 2 Resource services
+ * @author Didier Donsez
+ *
+ */
+
+public class Activator implements BundleActivator {
+
+	private final static Logger LOGGER = Logger.getLogger(Activator.class.getCanonicalName());
+
+	HelloResource bob;
+	HelloResource alice;
+	
+	@Override
+	public void start(BundleContext context) throws Exception {
+		LOGGER.fine("Example activator is starting");
+
+		try {
+			// GET coap://0.0.0.0:5683/Bob (with Copper plugin)
+			bob=new HelloResource("Bob");
+			bob.start(context);
+		} catch (Exception e) {
+			bob=null;
+			e.printStackTrace();
+		}
+		
+		try {
+			// GET coap://0.0.0.0:5683/Alice (with Copper plugin)
+			alice=new HelloResource("Alice");
+			alice.start(context);
+		} catch (Exception e) {
+			alice=null;
+			e.printStackTrace();
+		}
+		LOGGER.fine("Example activator is started");
+
+	}
+
+	@Override
+	public void stop(BundleContext context) throws Exception {
+		LOGGER.fine("Example activator is stopping");
+
+		try {
+			if(alice!=null) alice.stop(context);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		alice=null;
+
+		try {
+			if(bob!=null) bob.stop(context);
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		bob=null;
+		LOGGER.fine("Example activator is stopped");
+
+	}
+	
+    /*
+     * Definition of the Hello-World Resource
+     */
+    class HelloResource extends CoapResource implements BundleActivator /*, ManagedService */ {
+        
+    	private String name;
+    	
+        public HelloResource(String name) {
+            
+            // set resource identifier
+            super(name);
+
+        	this.name=name;
+        	            
+            // set display name
+            getAttributes().setTitle(name+" Resource");
+        }
+        
+        @Override
+        public void handleGET(CoapExchange exchange) {            
+            // respond to the request
+            exchange.respond("Hello "+name+"!");
+			LOGGER.fine(name+" Resource GET is invoked");
+        }
+        
+        ServiceRegistration<Resource> serviceRegistration;
+
+		@Override
+		public void start(BundleContext context) throws Exception {
+			LOGGER.fine(name+" Resource is starting");
+			serviceRegistration=(ServiceRegistration<Resource>) context.registerService(Resource.class.getName(),this,null);
+			LOGGER.fine(name+" Resource is registered");
+		}
+
+		@Override
+		public void stop(BundleContext context) throws Exception {
+			LOGGER.fine(name+" Resource is stopping");
+			if(serviceRegistration!=null) serviceRegistration.unregister();
+			LOGGER.fine(name+" Resource is unregistered");
+		}
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 		<module>cf-plugtest-server</module>
 		<module>cf-helloworld-client</module>
 		<module>cf-helloworld-server</module>
+		<module>cf-helloworld-osgi</module>
 		<module>cf-secure</module>
 		<module>cf-proxy</module>
 		<module>cf-benchmark</module>


### PR DESCRIPTION
This pull request proposes to add a BundleActivator to the californium-osgi bundle/project in order to start/stop a ManagedServer when the bundle is started/stopped. Requires the bundle http://central.maven.org/maven2/org/osgi/org.osgi.compendium/5.0.0/org.osgi.compendium-5.0.0.jar (and probably previous versions of it). The bundle has been tested with the Apache Felix Framework version 4.4.1 .