### PR TITLE
californium-proxy: Move doReceiveMessage(coapRequest) to its own Thread.

### DIFF
--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -203,6 +203,31 @@ public class HttpStack {
 			LOGGER.warning("exchanger was null for request "+request+" with hash "+request.hashCode());
 		}
 	}
+        /**
+	 * The Class CoapResponseWorker. This thread request a response from the
+         * lower layers. It is the producer of the producer/consumer pattern.
+	 */
+        private final class CoapRequestWorker extends Thread {
+		private final Request coapRequest;
+
+		/**
+		 * Instantiates a new coap response worker.
+		 *
+		 * @param name
+		 *            the name
+		 * @param coapRequest
+		 *            the coap request
+		 */
+		public CoapRequestWorker(String name, Request coapRequest) {
+			super(name);
+			this.coapRequest = coapRequest;
+                }
+
+		@Override
+		public void run() {
+                    doReceiveMessage(coapRequest);
+                }
+        }
 
 	/**
 	 * The Class CoapResponseWorker. This thread waits a response from the lower
@@ -212,6 +237,7 @@ public class HttpStack {
 		private final HttpAsyncExchange httpExchange;
 		private final HttpRequest httpRequest;
 		private final Request coapRequest;
+                private final Thread responseWorker;
 
 		/**
 		 * Instantiates a new coap response worker.
@@ -224,12 +250,15 @@ public class HttpStack {
 		 *            the http exchange
 		 * @param httpRequest
 		 *            the http request
+                 * @param responseWorker
+		 *            the coap response worker
 		 */
-		public CoapResponseWorker(String name, Request coapRequest, HttpAsyncExchange httpExchange, HttpRequest httpRequest) {
+		public CoapResponseWorker(String name, Request coapRequest, HttpAsyncExchange httpExchange, HttpRequest httpRequest, Thread responseWorker) {
 			super(name);
 			this.coapRequest = coapRequest;
 			this.httpExchange = httpExchange;
 			this.httpRequest = httpRequest;
+                        this.responseWorker = responseWorker;
 		}
 
 		/*
@@ -267,6 +296,8 @@ public class HttpStack {
 			} finally {
 				// remove the entry from the map
 				exchangeMap.remove(coapRequest);
+                                // the producer thread was unable to deliver a response at time, so we kill it.
+                                responseWorker.interrupt();
 //				if (Bench_Help.DO_LOG) 
 					LOGGER.finer("Entry removed from map");
 			}
@@ -438,18 +469,19 @@ public class HttpStack {
 //					if (Bench_Help.DO_LOG) 
 						LOGGER.finer("Fill exchange with: " + coapRequest+" with hash="+coapRequest.hashCode());
 
-					// the new thread will wait for the completion of
-					// the coap request
-					Thread worker = new CoapResponseWorker("HttpStack Worker", coapRequest, httpExchange, httpRequest);
+					// We create two threads
+                                        // The responseWorker will be in charge of producing a CoapResponse (producer)
+                                        // The requestWorker will be in charge of using this response to return it to the client
+                                        Thread requestWorker = new CoapRequestWorker("HttpStart Worker: consummer", coapRequest);
+                                        Thread responseWorker = new CoapResponseWorker("HttpStack Worker: producer", coapRequest, httpExchange, httpRequest, requestWorker);
 
-					// starting the "consumer thread" that will sleep waiting
-					// for the producer
-					worker.start();
+					// starting the producer and consummer thread
+					requestWorker.start();
+					responseWorker.start();
+
 //					if (Bench_Help.DO_LOG) 
 						LOGGER.finer("Started thread 'httpStack worker' to wait the response");
 
-					// send the coap request to the upper layers
-					doReceiveMessage(coapRequest);
 				} catch (InvalidMethodException e) {
 					LOGGER.warning("Method not implemented" + e.getMessage());
 					sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_WRONG_METHOD);
@@ -466,7 +498,7 @@ public class HttpStack {
 					LOGGER.warning("Exception in translation: "+e);
 					e.printStackTrace();
 					throw e;
-				}
+                                }
 			}
 
 			/*

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -381,7 +381,7 @@ public class HttpStack {
 
 							ioReactor.execute(ioEventDispatch);
 						} catch (IOException e) {
-							LOGGER.severe("Interrupted");
+							LOGGER.severe("I/O Exception in HttpStack: " + e.getMessage());
 						}
 
 						LOGGER.info("Shutdown HttpStack");

--- a/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
+++ b/californium-proxy/src/main/java/org/eclipse/californium/proxy/HttpStack.java
@@ -494,10 +494,6 @@ public class HttpStack {
 					LOGGER.warning("Failed to translate the http request in a valid coap request: " + e.getMessage());
 					sendSimpleHttpResponse(httpExchange, HttpTranslator.STATUS_TRANSLATION_ERROR);
 					return;
-				} catch (RuntimeException e) {
-					LOGGER.warning("Exception in translation: "+e);
-					e.printStackTrace();
-					throw e;
                                 }
 			}
 


### PR DESCRIPTION
This patch aims at addressing a bug in HttpStack:
doReceiveMessage(coapRequest) may be blocked waiting for a response
infinitely. If too much requests leading to to such behaviour are
received, all HTTP Stack I/O Threads with be stuck waiting for content
leading to refused requests.

This patch move the blocking call to doReceiveMessage(coapRequest) from
the HTTP I/O threads to a dedicaced thread. This one is launched in
http request handler (I/O thread), implementing the missing "producer"
thread of the producer/consummer patern. If no response is received at
time (GATEWAY_TIMEOUT), the two threads will be killed (one immediately,
one after issuing a default http response).

Maybe this patch will requires additional work for a better / proper
integration within the HTTP Stack. Meanwhile, it provide a working
solution for a know bug [1]. We are already using it in production.

[1] https://dev.eclipse.org/mhonarc/lists/cf-dev/msg00145.html

Signed-off-by: Mathieu Goessens <mathieu.goessens@telecom-bretagne.eu>