### PR TITLE
Replaced printStackTrace calls to LOGGER.log calls in CoapEndpoint an…

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoAPEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoAPEndpoint.java
@@ -391,7 +391,7 @@ public class CoAPEndpoint implements Endpoint {
 				try {
 					coapstack.sendRequest(request);
 				} catch (Throwable t) {
-					t.printStackTrace();
+					LOGGER.log(Level.SEVERE, t.getMessage(), t);
 				}
 			}
 		});
@@ -409,7 +409,7 @@ public class CoAPEndpoint implements Endpoint {
 					try {
 						coapstack.sendResponse(exchange, response);
 					} catch (Exception e) {
-						e.printStackTrace();
+					    LOGGER.log(Level.SEVERE, e.getMessage(), e);
 					}
 				}
 			});

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/EndpointManager.java
@@ -204,7 +204,7 @@ public class EndpointManager {
 	        		interfaces.add(inetAddresses.nextElement());
 	        }
 		} catch (SocketException e) {
-			e.printStackTrace();
+		    LOGGER.log(Level.SEVERE, e.getMessage(), e);
 		}
 		return interfaces;
 	}


### PR DESCRIPTION
Hello! Could you please consider this pull-request?

My app is connected to a error-tracking service - rollbar.com
Rollbar's library is implemented as appender to Logback.
I've forwarded JUL logs to logback, it is not difficult.
But I've found that if my app code was inside CoapHandler#onLoad and it thrown some RuntimeException, it just was forwarded to stdout and rollbar could not have it.
Sure, now I have try/catched my handlers, but I wish also Californium's unhandled exceptions be forwarded to the rollbar too.
Is there any reason to have such printStackTrace calls?

Regards, Eugene.