### PR TITLE
Destroy CoapStack when CoapEndpoint is destroyed

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/CoapEndpoint.java
@@ -310,6 +310,7 @@ public class CoapEndpoint implements Endpoint {
 		if (started)
 			stop();
 		connector.destroy();
+		coapstack.destroy();
 		for (EndpointObserver obs:observers)
 			obs.destroyed(this);
 	}

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/AbstractLayer.java
@@ -160,5 +160,11 @@ public abstract class AbstractLayer implements Layer {
 			throw new IllegalArgumentException("Rejecting an "+message.getType()+" is not allowed");
 		sendEmptyMessage(exchange, EmptyMessage.newRST(message));
 	}
+
+
+	@Override
+	public void destroy() {
+
+	}
 	
 }

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CoapStack.java
@@ -148,7 +148,12 @@ public class CoapStack {
 	public void setDeliverer(MessageDeliverer deliverer) {
 		this.deliverer = deliverer;
 	}
-	
+
+	public void destroy() {
+		for (Layer layer:layers)
+			layer.destroy();
+	}
+
 	private class StackTopAdapter extends AbstractLayer {
 		
 		public void sendRequest(Request request) {
@@ -213,7 +218,7 @@ public class CoapStack {
 		public void sendEmptyMessage(Exchange exchange, EmptyMessage message) {
 			outbox.sendEmptyMessage(exchange, message);
 		}
-		
+
 	}
 	
 	public boolean hasDeliverer() {

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Layer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/Layer.java
@@ -132,8 +132,10 @@ public interface Layer {
 	 * @param executor the new executor
 	 */
 	public void setExecutor(ScheduledExecutorService executor);
-	
-	
+
+	public void destroy();
+
+
 	/**
 	 * A builder that constructs the stack from the top to the bottom. The
 	 * returned list of layers is in the same order as added to the stack.


### PR DESCRIPTION
In the current implementation unused Endpoints and CoAPServers are not garbage collected. This due to the config observe relation between the default `NetworkConfig` and the layers (`ReliabilityLayer` and `BlockwiseLayer`). 


Reference chain:
**static `NetworkConfig.default`** > `NetworkConfig` > `BlockwiseLayer`  > `ObserveLayer` >  `StackTopAdapter` (inner class of) `CoapStack` > `OutboxImpl`  (inner class of) **`CoapEndpoint`** > `ServerMessageDeliverer` > `RootResource`  (inner class of) **`CoapServer`**
Test code:
```java
while (true) {
     CoapServer cs = new CoapServer(0);
     cs.add(new CoapResource("Test"));
     cs.start();
     Thread.sleep(10);
     cs.destroy();
     // Force GC
     System.gc();
}
```
Before fix:
<img width="1199" alt="before" src="https://cloud.githubusercontent.com/assets/1868109/11265366/0a735cc8-8e9c-11e5-8fff-37a2824267e0.png">
After fix:
<img width="1194" alt="after" src="https://cloud.githubusercontent.com/assets/1868109/11266348/372e6c96-8ea4-11e5-89e1-c358d863cc94.png">
