### PR TITLE
Spelling mistake in REQUEST_CODE_UPPER_BOUND

### DIFF
--- a/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/coap/CoAP.java
@@ -300,7 +300,7 @@ public class CoAP {
 		public static final int REQUEST_CODE_LOWER_BOUND = 1;
 		
 		/** The highest value of a request code. */
-		public static final int REQUEST_CODE_UPPER_BOUNT = 31;
+		public static final int REQUEST_CODE_UPPER_BOUND = 31;
 		
 		/** The lowest value of a response code. */
 		public static final int RESPONSE_CODE_LOWER_BOUND = 64;

--- a/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
+++ b/californium-core/src/main/java/org/eclipse/californium/core/network/stack/CongestionControlLayer.java
@@ -483,4 +483,3 @@ public abstract class CongestionControlLayer extends ReliabilityLayer {
 	}
 }
 
-


### PR DESCRIPTION
I have just got your source to compile locally, and got this spelling mistake in your CoAP class.